### PR TITLE
merge sub/configs back into main config based on environment

### DIFF
--- a/tasks/environment.js
+++ b/tasks/environment.js
@@ -56,6 +56,11 @@
     };
     grunt.config.get('environment.environments').forEach(function(env) {
       return grunt.registerTask("environment:" + env, function() {
+        var config = grunt.config("default") || {};
+        grunt.util._.merge(config, grunt.config(env));        
+        Object.keys(config).forEach(function(key) {
+          grunt.config(key, config[key]);
+        });
         writeBuildConfig({
           env: env
         });


### PR DESCRIPTION
This allows your config to look like this 

``` JavaScript
module.exports = function(grunt) {
  require("load-grunt-config")(grunt, {
    config: {
      hostname: "http://www.thingy.co.uk",
      template_dir: "templates",
      development: {
        output_dir: "www"
      },
      production: {
        output_dir: "./../sites/thingy-2.2.2"
      },
      environment: {
        "default": "development",
        environments: ["development", "production"],
        version: function() {
          return grunt.file.readJSON("package.json")["version"];
        }
      }
    }
  });
  return grunt.loadTasks("tasks");
};
```

so that the environment you are using gets merged back into the main config

```
grunt environment:production
```

makes the config behave as if it were:

``` JavaScript
module.exports = function(grunt) {
  require("load-grunt-config")(grunt, {
    config: {
      hostname: "http://www.thingy.co.uk",
      template_dir: "templates",
      output_dir: "./../sites/thingy-2.2.2",
      environment: {grunt.config.get('environment.env')
        "default": "development",
        environments: ["development", "production"],
        version: function() {
          return grunt.file.readJSON("package.json")["version"];
        }
      }
    }
  });
  return grunt.loadTasks("tasks");
};
```

This way you don't need to do comparisons with environment.env in your tasks.
