### PR TITLE
Extend to allow pulling environment vars from global config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-environment",
   "description": "Add environment-centric logic to your Grunt builds",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "homepage": "https://github.com/logankoester/grunt-environment",
   "author": {
     "name": "Logan Koester",

--- a/tasks/environment.js
+++ b/tasks/environment.js
@@ -90,6 +90,14 @@
     grunt.environment = function() {
       return grunt.config.get('environment.env');
     };
+    grunt.environmentVar = function(name) {
+      var config = grunt.config.get(grunt.config.get('environment.env'));
+      if (config && config[name] !== undefined) {
+        return config[name];
+      }
+      grunt.log.error('environment config not found for variable"'+name+'"');
+      return null;
+    };
     return initEnvironment();
   };
 


### PR DESCRIPTION
Hi,

I have extended the plugin to allow the following usage within the GruntFile. 

Consider this config file:
{  
  development: {
    jsFileName:  'development.js',
    cssFileName: 'development.css'
  },
  production: {
    jsFileName:  'production.min.js',
    cssFileName: 'production.min.css'
  },
  environment: {
    default: 'development',
    environments: ['development', 'production'],
    version: function(){
      return grunt.file.readJSON('package.json')['version']
    }
  }
}

Allows this usage:
sed: {
  js: {
    path: 'build/index.html',
    pattern: '%SRC_JAVASCRIPT%',
    replacement: '<%= grunt.environmentVar("jsFileName") %>',
  },
  css: {
    path: 'build/index.html',
    pattern: '%SRC_CSS%',
    replacement: '<%= grunt.environmentVar("cssFileName") %>',
  }
},  

Which pulls out different values depending on the current environment within strings. very cool :)

Please consider pulling into the main plugin.

Thanks
Jae.
